### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,14 @@ jobs:
           plugins: ""
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@1b5b448b98e58ba90d1a1a1d9fcb72ca2263be46 # v1
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: reports/results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Fail if tests failed
         shell: bash
         if: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.11"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "It's written in Rust!",
   "main": "src/main.rs",
   "scripts": {
-    "prettier": "prettier --write .",
+    "format": "prettier --write .",
     "release": "semantic-release"
   },
   "engines": {


### PR DESCRIPTION
- **chore(deps): update dependency @semantic-release/github to v10.1.5**
- **chore(deps): update returntocorp/semgrep docker tag to v1.85.0**
- **chore(deps): update dependency @semantic-release/github to v10.1.6**
- **chore(deps): update rui314/setup-mold digest to 0bf4f07**
- **chore(deps): update dependency semantic-release to v24.1.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update github/codeql-action action to v3.26.3**
- **chore(deps): update dependency @semantic-release/github to v10.1.7**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 3614a93**
- **chore(deps): update dependency node to v20.17.0**
- **chore(deps): update github/codeql-action action to v3.26.4**
- **chore(deps): update github/codeql-action action to v3.26.5**
- **chore(deps): lock file maintenance**
- **chore(deps): update npm to >=10.8.3**
- **fix: report tests to codecov for tracking**
- **chore: formatting**
- **chore(deps): pin codecov/test-results-action action to 1b5b448**
- **chore(deps): update github/codeql-action action to v3.26.6**
