### PR TITLE
update from upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,8 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
-source = "git+https://github.com/eyre-rs/eyre?rev=c4ee249f7c51dc6452e8704ae8d117d90d6eeebc#c4ee249f7c51dc6452e8704ae8d117d90d6eeebc"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -76,7 +71,8 @@ dependencies = [
 [[package]]
 name = "color-spantrace"
 version = "0.2.2"
-source = "git+https://github.com/eyre-rs/eyre?rev=c4ee249f7c51dc6452e8704ae8d117d90d6eeebc#c4ee249f7c51dc6452e8704ae8d117d90d6eeebc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -86,10 +82,10 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "1.0.0"
-source = "git+https://github.com/eyre-rs/eyre?rev=c4ee249f7c51dc6452e8704ae8d117d90d6eeebc#c4ee249f7c51dc6452e8704ae8d117d90d6eeebc"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
- "autocfg",
  "indenter",
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ non_ascii_idents = { level = "deny", priority = 127 }
 
 [dependencies]
 bytes = "1.10.1"
-color-eyre = { git = "https://github.com/eyre-rs/eyre", rev = "c4ee249f7c51dc6452e8704ae8d117d90d6eeebc" }
+color-eyre = "0.6.4"
+libc = "0.2.172"
+socket2 = "0.5.9"
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = [
     "net",
@@ -47,10 +49,8 @@ tokio = { version = "1.44.2", features = [
     "signal",
 ] }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-error = "0.2.1"
-socket2 = "0.5.9"
-libc = "0.2.172"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 # netdev = "0.31.0"
 zerocopy = { version = "0.8.25", features = ["derive"] }
 


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.120.1**
- **chore(deps): update rust:1.86.0 docker digest to ff735b1**
- **chore(deps): update rust:1.86.0 docker digest to 13e8910**
- **chore(deps): update rust:1.86.0 docker digest to 173b003**
- **chore(deps): update rust:1.86.0 docker digest to f2b92e8**
- **chore(deps): update rust:1.86.0 docker digest to 640960f**
- **chore(deps): update github/codeql-action action to v3.28.17**
- **chore(deps): bump color eyre**
