### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN touch ./src/main.rs
 RUN --mount=type=cache,target=/build/${APPLICATION_NAME}/target \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
     --mount=type=cache,id=cargo-registery,target=/usr/local/cargo/registry/,sharing=locked \
-    ./build.sh install --path . --target ${TARGET} --root /output
+    ./build.sh install --path . --locked --target ${TARGET} --root /output
 
 # Container user setup
 FROM --platform=${BUILDPLATFORM} alpine:3.22.0@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS passwd-build


### PR DESCRIPTION
- **chore(deps): update returntocorp/semgrep docker tag to v1.123.0**
- **fix(deps): update rust crate openssl to 0.10.73**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 6a2d391**
- **fix(deps): update rust crate color-eyre to 0.6.5**
- **chore(deps): update alpine docker tag to v3.22.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update rui314/setup-mold digest to b395809**
- **chore(deps): update github/codeql-action action to v3.28.19**
- **chore(deps): update returntocorp/semgrep docker tag to v1.124.0**
- **fix: install with locked to prevent cargo from updating deps during cargo install**
